### PR TITLE
Localize landing page to Catalan and center map on Catalonia

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="ca">
 
 <head>
 
@@ -16,7 +16,7 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
-  <title>Inglés divertido · La Casita de Inglés</title>
+  <title>Anglès divertit · La Casita de Inglés</title>
 
   <link rel="icon" href="img/favicon.png" type="image/x-icon">
 
@@ -166,7 +166,7 @@
         "user_ratings_total": 98
       },
       {
-        "name": "Poblenou (Próximamente)",
+        "name": "Poblenou (Pròximament)",
         "address": "Carrer de Llull, 256, Barcelona, 08005",
         "phone": "722 501 660",
         "email": "poblenou@lacasitadeingles.com",
@@ -221,7 +221,7 @@
         "user_ratings_total": 80
       },
       {
-        "name": "Vigo (Próximamente)",
+        "name": "Vigo (Pròximament)",
         "address": "Rúa do Uruguai, 15, Vigo, 36201",
         "phone": "623 202 594",
         "email": "vigo@lacasitadeingles.com",
@@ -325,15 +325,15 @@
       <nav x-cloak x-show="menuOpen" @click.away="menuOpen=false"
         class="absolute right-2 top-full mt-2 w-48 bg-white border border-gray-200 shadow-lg rounded-xl text-right py-2 px-0 flex flex-col gap-0 z-50">
         <a href="#programas" @click="menuOpen=false"
-          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium rounded-t-xl transition-colors">Programas</a>
+          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium rounded-t-xl transition-colors">Programes</a>
         <a href="#beneficios" @click="menuOpen=false"
-          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium transition-colors">Beneficios</a>
+          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium transition-colors">Beneficis</a>
         <a href="#testimonials" @click="menuOpen=false"
-          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium transition-colors">Testimonios</a>
+          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium transition-colors">Testimonis</a>
         <a href="#locations" @click="menuOpen=false"
-          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium transition-colors">Academias</a>
+          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium transition-colors">Acadèmies</a>
         <a href="#" @click.prevent="openForm(''); menuOpen=false"
-          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium rounded-b-xl transition-colors">Contacto</a>
+          class="block px-6 py-3 text-gray-800 hover:bg-brand-pink/10 hover:text-brand-pink font-medium rounded-b-xl transition-colors">Contacte</a>
       </nav>
     </div>
 
@@ -342,127 +342,127 @@
   <!-- Hero -->
   <section id="hero" :class="[heroClass, 'relative text-white text-center flex flex-col items-center justify-center']">
     <div class="absolute inset-0 bg-gradient-to-b from-black/60 to-black/30"></div>
-    <h1 class="relative z p-1-10 text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4">¡El Inglés más divertido!</h1>
-    <p class="relative z-10 text-lg sm:text-xl mb-4 p-1">Profesores nativos · Grupos reducidos · Play-Based Learning</p>
+    <h1 class="relative z p-1-10 text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4">L'anglès més divertit!</h1>
+    <p class="relative z-10 text-lg sm:text-xl mb-4 p-1">Professors nadius · Grups reduïts · Play-Based Learning</p>
     <ul class="relative z-10 flex flex-wrap justify-center gap-4 text-xs text-white/80 mb-8">
-      <li>20 años de experiencia</li>
-      <li class="hidden sm:inline">17 k seguidores</li>
-      <li>14 academias en Madrid</li>
+      <li>20 anys d'experiència</li>
+      <li class="hidden sm:inline">17 k seguidors</li>
+      <li>14 acadèmies a Madrid</li>
     </ul>
     <div class="relative z-10 mb-6">
       <a href="#" @click.prevent="openReviews()"
         class="inline-flex items-center gap-1 bg-white text-black font-semibold py-1.5 px-3 rounded-full shadow hover:bg-yellow-300 text-sm">
         <span x-text="weightedRating"></span>
         <span x-html="starIcons(parseFloat(weightedRating))" class="ml-1"></span>
-        <span x-text="`(${Number(totalReviews).toLocaleString('es-ES')} reseñas)`"></span>
+        <span x-text="`(${Number(totalReviews).toLocaleString('ca-ES')} ressenyes)`"></span>
       </a>
     </div>
     <div class="relative z-10 flex flex-col sm:flex-row gap-4">
       <a href="#" @click.prevent="openForm('')"
         class="cta-book inline-block bg-white text-brand-pink hover:bg-gray-100 font-bold py-4 px-8 rounded-full shadow-xl text-lg transition">Reserva
-        tu clase GRATIS</a>
+        la teva classe GRATIS</a>
       <a href="#programas"
-        class="inline-block border-2 border-white hover:border-gray-200 text-white hover:text-gray-200 font-bold py-4 px-8 rounded-full shadow text-lg transition">Ver
-        programas</a>
+        class="inline-block border-2 border-white hover:border-gray-200 text-white hover:text-gray-200 font-bold py-4 px-8 rounded-full shadow text-lg transition">Veure
+        programes</a>
     </div>
   </section>
 
 
   <!-- Programas -->
   <section id="programas" class="max-w-5xl mx-auto px-4 pt-16">
-    <h2 class="text-3xl font-extrabold text-center mb-6">Nuestros Programas</h2>
-    <p class="text-center mb-8">En La Casita de Inglés aplicamos el Play-Based Learning adaptado a cada edad.</p>
+    <h2 class="text-3xl font-extrabold text-center mb-6">Els nostres programes</h2>
+    <p class="text-center mb-8">A La Casita de Inglés apliquem el Play-Based Learning adaptat a cada edat.</p>
     <div class="space-y-4">
       <details class="border rounded-2xl p-4">
-        <summary class="cursor-pointer text-xl font-bold" translate="no">Babies (0-2 años)</summary>
+        <summary class="cursor-pointer text-xl font-bold" translate="no">Babies (0-2 anys)</summary>
         <div class="mt-4">
-          <h3 class="text-2xl font-extrabold text-center mb-6">Exploran en confianza</h3>
+          <h3 class="text-2xl font-extrabold text-center mb-6">Exploren amb confiança</h3>
           <div class="grid gap-8 sm:grid-cols-2 justify-center">
             <div class="border rounded-2xl p-6 shadow hover:shadow-lg transition flex flex-col bg-gradient-to-br from-brand-yellow/10 to-white info-card">
               <h3 class="text-xl font-bold mb-1" translate="no">Baby &amp; Me</h3>
-              <p class="mb-4">Inmersión total en inglés desde el primer año de vida. En grupos hiper-reducidos, los bebés
-                exploran música, movimiento y juego sensorial junto a un adulto de confianza, guiados por profes nativos.
-                El vínculo afectivo y la exposición auditiva temprana activan las áreas de adquisición del idioma en su
-                momento más plástico.</p>
-              <p class="text-sm mb-2">👥 Máx. 6 familias</p>
-              <p class="text-sm mb-2">💂‍♀️ Profes 100% nativos</p>
+              <p class="mb-4">Immersió total en anglès des del primer any de vida. En grups molt reduïts, els nadons
+                exploren música, moviment i joc sensorial juntament amb un adult de confiança, guiats per professors natius.
+                El vincle afectiu i l'exposició auditiva primerenca activen les àrees d'adquisició de l'idioma en el seu
+                moment més plàstic.</p>
+              <p class="text-sm mb-2">👥 Màx. 6 famílies</p>
+              <p class="text-sm mb-2">💂‍♀️ Professors 100% natius</p>
               <a href="#" @click.prevent="openForm('Baby &amp; Me')"
                 class="cta-book mt-auto inline-block bg-brand-pink hover:bg-brand-purple text-white font-bold py-2 px-6 rounded-full">Reserva
-                tu clase gratuita</a>
+                la teva classe gratuïta</a>
             </div>
           </div>
         </div>
       </details>
 
       <details id="kids-panel" class="border rounded-2xl p-4" open>
-        <summary class="cursor-pointer text-xl font-bold" translate="no">Kids (3–8 años)</summary>
+        <summary class="cursor-pointer text-xl font-bold" translate="no">Kids (3–8 anys)</summary>
         <div class="mt-4">
-          <h3 class="text-2xl font-extrabold text-center mb-6">Aprenden sin darse cuenta...</h3>
+          <h3 class="text-2xl font-extrabold text-center mb-6">Aprenen sense adonar-se'n...</h3>
           <div class="grid gap-8 sm:grid-cols-2 justify-center">
             <div class="border rounded-2xl p-6 shadow hover:shadow-lg transition flex flex-col bg-gradient-to-br from-brand-purple/10 to-white info-card">
               <h3 class="text-xl font-bold mb-1" translate="no">Home Circle</h3>
-              <p class="mb-4">Nuestra experiencia estrella: 2 horas seguidas a la semana. Rotación cada 30 min en espacios
-                de juego, creatividad y movimiento:</p>
+              <p class="mb-4">La nostra experiència estrella: 2 hores seguides a la setmana. Rotació cada 30 min en espais
+                de joc, creativitat i moviment:</p>
               <ul class="list-disc list-inside text-sm mb-4 space-y-1">
-                <li>🎨 Sala de Manualidades y Cocina</li>
-                <li>💃 Sala de Baile</li>
-                <li>🎲 Sala de Juegos de Mesa</li>
-                <li>🎭 Sala de Teatro y Yoga</li>
+                <li>🎨 Sala de Manualitats i Cuina</li>
+                <li>💃 Sala de Ball</li>
+                <li>🎲 Sala de Jocs de Taula</li>
+                <li>🎭 Sala de Teatre i Ioga</li>
               </ul>
-              <p class="text-sm mb-2">👥 Máx. 8 alumnos | Agrupamos por edad</p>
-              <p class="text-sm mb-2">💂‍♀️ Profes 100% nativos</p>
-              <p class="text-sm text-gray-600 mb-6">L‑V 17:30–19:30 | Sáb 11:00–13:00</p>
+              <p class="text-sm mb-2">👥 Màx. 8 alumnes | Agrupem per edat</p>
+              <p class="text-sm mb-2">💂‍♀️ Professors 100% natius</p>
+              <p class="text-sm text-gray-600 mb-6">Dl‑Dv 17:30–19:30 | Ds 11:00–13:00</p>
               <a href="#" @click.prevent="openForm('Home Circle')"
                 class="cta-book mt-auto inline-block bg-brand-pink hover:bg-brand-purple text-white font-bold py-2 px-6 rounded-full">Reserva
-                tu clase gratuita</a>
+                la teva classe gratuïta</a>
             </div>
             <div class="border rounded-2xl p-6 shadow hover:shadow-lg transition flex flex-col bg-gradient-to-br from-brand-purple/10 to-white info-card">
               <h3 class="text-xl font-bold mb-1" translate="no">Home Express Kids</h3>
-              <p class="mb-4">Mismo método que Home Circle, pero en 1 hora semanal con cambio de actividad cada 15 min:
-                Baile, Teatro, Manualidades y Juegos de mesa en una sola sala.</p>
-              <p class="text-sm mb-2">👥 Máx. 8 alumnos | Agrupamos por edad</p>
-              <p class="text-sm mb-2">💂‍♀️ Profes 100% nativos</p>
-              <p class="text-sm text-gray-600 mb-6">L‑V 17:30–18:30 / 18:30–19:30<br>Sáb 11:00–12:00 / 12:00–13:00</p>
+              <p class="mb-4">Mateix mètode que Home Circle, però en 1 hora setmanal amb canvi d'activitat cada 15 min:
+                Ball, Teatre, Manualitats i Jocs de taula en una sola sala.</p>
+              <p class="text-sm mb-2">👥 Màx. 8 alumnes | Agrupem per edat</p>
+              <p class="text-sm mb-2">💂‍♀️ Professors 100% natius</p>
+              <p class="text-sm text-gray-600 mb-6">Dl‑Dv 17:30–18:30 / 18:30–19:30<br>Ds 11:00–12:00 / 12:00–13:00</p>
               <a href="#" @click.prevent="openForm('Home Express Kids')"
                 class="cta-book mt-auto inline-block bg-brand-pink hover:bg-brand-purple text-white font-bold py-2 px-6 rounded-full">Reserva
-                tu clase gratuita</a>
+                la teva classe gratuïta</a>
             </div>
           </div>
         </div>
       </details>
 
       <details id="juniors-panel" class="border rounded-2xl p-4">
-        <summary class="cursor-pointer text-xl font-bold" translate="no">Juniors (9–12 años)</summary>
+        <summary class="cursor-pointer text-xl font-bold" translate="no">Juniors (9–12 anys)</summary>
         <div class="mt-4">
-          <h3 class="text-2xl font-extrabold text-center mb-6">Desarrollan sus habilidades en inglés</h3>
+          <h3 class="text-2xl font-extrabold text-center mb-6">Desenvolupen les seves habilitats en anglès</h3>
           <div class="grid gap-8 sm:grid-cols-2 justify-center">
             <div class="border rounded-2xl p-6 shadow hover:shadow-lg transition flex flex-col bg-gradient-to-br from-brand-teal/10 to-white info-card">
               <h3 class="text-xl font-bold mb-1" translate="no">Home Run</h3>
-              <p class="mb-4">Para los pre-adolescentes. 2 horas semanales en formato rotativo. Trabajamos reading,
-                writing, listening y speaking con retos creativos (escape-rooms, experiments, videoblogs, ...).</p>
+              <p class="mb-4">Per als preadolescents. 2 hores setmanals en format rotatiu. Treballem reading,
+                writing, listening i speaking amb reptes creatius (escape rooms, experiments, videoblogs, ...).</p>
               <ul class="list-disc list-inside text-sm mb-4 space-y-1">
-                <li>🎨 Sala de Manualidades y Cocina</li>
-                <li>🎯 Sala de Baile y Juegos Activos</li>
-                <li>🗣️ Sala de Juegos de Mesa y Conversación</li>
-                <li>🎭 Sala de Teatro y Yoga</li>
+                <li>🎨 Sala de Manualitats i Cuina</li>
+                <li>🎯 Sala de Ball i Jocs Actius</li>
+                <li>🗣️ Sala de Jocs de Taula i Conversa</li>
+                <li>🎭 Sala de Teatre i Ioga</li>
               </ul>
-              <p class="text-sm mb-2">👥 Máx. 8 alumnos | Agrupamos por nivel Cambridge YLE/PET</p>
-              <p class="text-sm mb-2">💂‍♀️ Profes 100% nativos</p>
-              <p class="text-sm text-gray-600 mb-6">L‑V 17:30–19:30 | Sáb 11:00–13:00</p>
+              <p class="text-sm mb-2">👥 Màx. 8 alumnes | Agrupem per nivell Cambridge YLE/PET</p>
+              <p class="text-sm mb-2">💂‍♀️ Professors 100% natius</p>
+              <p class="text-sm text-gray-600 mb-6">Dl‑Dv 17:30–19:30 | Ds 11:00–13:00</p>
               <a href="#" @click.prevent="openForm('Home Run')"
                 class="cta-book mt-auto inline-block bg-brand-pink hover:bg-brand-purple text-white font-bold py-2 px-6 rounded-full">Reserva
-                tu clase gratuita</a>
+                la teva classe gratuïta</a>
             </div>
             <div class="border rounded-2xl p-6 shadow hover:shadow-lg transition flex flex-col bg-gradient-to-br from-brand-teal/10 to-white info-card">
               <h3 class="text-xl font-bold mb-1" translate="no">Home Express Juniors</h3>
-              <p class="mb-4">Mismo método que Home Run, pero en 1 hora semanal con cambio de actividad cada 15 min:
-                Baile, Teatro, Manualidades y Juegos de mesa en una sola sala.</p>
-              <p class="text-sm mb-2">👥 Máx. 8 alumnos | Agrupamos por nivel Cambridge YLE/PET</p>
-              <p class="text-sm mb-2">💂‍♀️ Profes 100% nativos</p>
-              <p class="text-sm text-gray-600 mb-6">L‑V 17:30–18:30 / 18:30–19:30<br>Sáb 11:00–12:00 / 12:00–13:00</p>
+              <p class="mb-4">Mateix mètode que Home Run, però en 1 hora setmanal amb canvi d'activitat cada 15 min:
+                Ball, Teatre, Manualitats i Jocs de taula en una sola sala.</p>
+              <p class="text-sm mb-2">👥 Màx. 8 alumnes | Agrupem per nivell Cambridge YLE/PET</p>
+              <p class="text-sm mb-2">💂‍♀️ Professors 100% natius</p>
+              <p class="text-sm text-gray-600 mb-6">Dl‑Dv 17:30–18:30 / 18:30–19:30<br>Ds 11:00–12:00 / 12:00–13:00</p>
               <a href="#" @click.prevent="openForm('Home Express Juniors')"
                 class="cta-book mt-auto inline-block bg-brand-pink hover:bg-brand-purple text-white font-bold py-2 px-6 rounded-full">Reserva
-                tu clase gratuita</a>
+                la teva classe gratuïta</a>
             </div>
           </div>
         </div>
@@ -470,52 +470,52 @@
     </div>
   </section>
 
-  <!-- Beneficios -->
+  <!-- Beneficis -->
   <section id="beneficios" class="max-w-5xl mx-auto px-4 py-8">
     <div class="bg-brand-yellow/10 border-l-4 border-brand-pink p-6 rounded-2xl info-card">
       <h3 class="text-2xl font-bold text-brand-pink mb-4 flex items-center gap-2">
-        <span class="text-3xl">🌟</span> Beneficios para tu familia
+        <span class="text-3xl">🌟</span> Beneficis per a la teva família
       </h3>
       <ul class="list-disc list-inside space-y-2 text-gray-700 leading-relaxed">
-        <li><strong>Desgravable en la Renta:</strong> la única extraescolar que reduce tu IRPF.</li>
-        <li><strong>Clases recuperables 30 días:</strong> reprograma online sin papeleos.</li>
-        <li><strong>Descuento familiar:</strong> –5 % al segundo hermano y –10 % al tercero.</li>
-        <li><strong>Promoción “Bring a Friend”:</strong> –20 € para ti y para tu amigo <em>(acumulable)</em>.</li>
+        <li><strong>Deduïble a la renda:</strong> l'única extraescolar que redueix el teu IRPF.</li>
+        <li><strong>Classes recuperables 30 dies:</strong> reprograma online sense paperassa.</li>
+        <li><strong>Descompte familiar:</strong> –5 % al segon germà i –10 % al tercer.</li>
+        <li><strong>Promoció “Bring a Friend”:</strong> –20 € per a tu i per al teu amic <em>(acumulable)</em>.</li>
       </ul>
     </div>
   </section>
 
   <!-- Instagram Feed -->
   <section class="py-16 bg-brand-yellow px-4">
-    <h2 class="text-3xl font-extrabold text-center text-white mb-6">Únete a nuestra comunidad
+    <h2 class="text-3xl font-extrabold text-center text-white mb-6">Uneix-te a la nostra comunitat
       <a href="https://www.instagram.com/casitadeingles/" target="_blank" rel="noopener noreferrer"
         class="text-brand-pink hover:text-brand-purple underline">@casitadeingles</a>
     </h2>
-    <p class="text-center mt-4 text-gray-600">16.000 familias nos siguen para ver historias diarias de nuestras clases
+    <p class="text-center mt-4 text-gray-600">16.000 famílies ens segueixen per veure històries diàries de les nostres classes
     </p>
   </section>
 
   <!-- Testimonials -->
   <section id="testimonials" class="bg-gray-50 py-16 px-4">
     <h2 class="text-3xl font-extrabold text-center mb-12">
-      ¡Lo dicen los padres!
+      Ho diuen els pares!
     </h2>
     <div class="text-center mb-12">
       <a href="#" @click.prevent="openReviews()"
         class="inline-block bg-brand-yellow/20 text-black font-bold py-3 px-4 rounded-xl shadow-lg text-xl">
         <span class="inline-block bg-white text-brand-pink px-2 py-1 rounded-md m-1"
-          x-text="Number(totalReviews).toLocaleString('es-ES')"></span>
-        familias nos dan
+          x-text="Number(totalReviews).toLocaleString('ca-ES')"></span>
+        famílies ens donen
         <div class="inline-block bg-white px-2 py-1 rounded-md m-1">
           <span class="text-brand-pink" x-text="weightedRating"></span>
           <span x-html="starIcons(parseFloat(weightedRating))" class="mx-1"></span>
         </div>
-        en
+        a
         <span class="text-blue-600 underline">Google</span>
       </a>
     </div>
     <div class="max-w-3xl mx-auto aspect-video">
-      <iframe class="w-full h-full rounded-xl shadow" title="Testimonios La Casita de Inglés"
+      <iframe class="w-full h-full rounded-xl shadow" title="Testimonis La Casita de Inglés"
         src="https://www.youtube.com/embed/5k7RnPEJg9w?si=k_GH0kZg88Rl7K92" title="YouTube video player" frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
@@ -528,10 +528,10 @@
     <p class="text-center mb-8">Encuentra la academia que mejor te venga</p>
     <div id="search-controls" class="mb-4 bg-gray-100 p-4 rounded-lg flex flex-col sm:flex-row sm:items-center gap-2 text-sm">
       <div class="flex-1 flex flex-col sm:flex-row gap-2">
-        <input x-model="postcode" type="text" placeholder="Introduce tu código postal" class="flex-1 px-2 py-1 rounded text-base">
-        <button @click="dataLayer.push({event: 'searchedAcademy', search_method: 'postcode'}); findByPostcode()" class="bg-white text-brand-pink border-2 border-brand-pink px-3 py-1 rounded w-full sm:w-auto">Buscar por código postal</button>
+        <input x-model="postcode" type="text" placeholder="Introdueix el teu codi postal" class="flex-1 px-2 py-1 rounded text-base">
+        <button @click="dataLayer.push({event: 'searchedAcademy', search_method: 'postcode'}); findByPostcode()" class="bg-white text-brand-pink border-2 border-brand-pink px-3 py-1 rounded w-full sm:w-auto">Cerca per codi postal</button>
       </div>
-      <button @click="dataLayer.push({event: 'searchedAcademy', search_method: 'gps'}); findClosestLocation()" class="bg-white text-brand-pink border-2 border-brand-pink px-3 py-1 rounded w-full sm:w-auto font-bold">Usar mi ubicación</button>
+      <button @click="dataLayer.push({event: 'searchedAcademy', search_method: 'gps'}); findClosestLocation()" class="bg-white text-brand-pink border-2 border-brand-pink px-3 py-1 rounded w-full sm:w-auto font-bold">Utilitza la meva ubicació</button>
     </div>
     <template x-if="closestLocation">
       <div id="found-info" class="mb-4 bg-gray-100 p-4 rounded text-sm shadow">
@@ -540,9 +540,9 @@
         <p x-text="closestLocation.email"></p>
         <p x-text="closestLocation.phone"></p>
         <template x-if="closestDistance !== null">
-          <p class="text-brand-pink font-semibold" x-text="`A ${closestDistance.toFixed(1)} km de ti`"></p>
+          <p class="text-brand-pink font-semibold" x-text="`A ${closestDistance.toFixed(1)} km de tu`"></p>
         </template>
-        <button @click="openForm('')" class="bg-brand-pink text-white px-3 py-1 rounded mt-2 w-full sm:w-auto cta-book">Reserva tu clase gratuita</button>
+        <button @click="openForm('')" class="bg-brand-pink text-white px-3 py-1 rounded mt-2 w-full sm:w-auto cta-book">Reserva la teva classe gratuïta</button>
       </div>
     </template>
     <div class="relative w-full h-96 rounded-2xl overflow-hidden shadow">
@@ -550,7 +550,7 @@
     </div>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        const map = L.map('map').setView([40.4066036, -3.6786666], 11);
+        const map = L.map('map').setView([41.593, 1.52], 8);
         window.MAP = map;
         // Use CartoDB Positron (light, greyish) tiles
         L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
@@ -576,11 +576,11 @@
 
   <!-- Final CTA -->
   <section class="relative bg-brand-teal text-white text-center py-12 px-4">
-    <h2 class="text-3xl md:text-4xl font-extrabold mb-4">¿Listo para que tus peques amen el inglés?</h2>
-    <p class="mb-8 text-lg md:text-xl">Abrimos grupos el <strong>1 de septiembre</strong> · ¡Plazas limitadas!</p>
+    <h2 class="text-3xl md:text-4xl font-extrabold mb-4">Preparat perquè els teus petits estimin l'anglès?</h2>
+    <p class="mb-8 text-lg md:text-xl">Obrim grups l'<strong>1 de setembre</strong> · Places limitades!</p>
     <a href="#" @click.prevent="openForm('')"
       class="cta-book inline-block bg-white text-brand-pink hover:bg-gray-100 font-bold py-4 px-8 mb-6 text-lg rounded-full shadow-xl transition">Reserva
-      tu clase GRATIS</a>
+      la teva classe GRATIS</a>
     <svg class="absolute bottom-0 left-0 w-full" viewBox="0 0 1440 75" xmlns="http://www.w3.org/2000/svg"
       preserveAspectRatio="none">
       <path d="M0,30 C360,90 720,-30 1080,30 C1260,60 1440,45 1440,45 L1440,75 L0,75 Z" fill="#ffffff" />
@@ -592,8 +592,8 @@
     <p>©
       <script>document.write(new Date().getFullYear());</script> <a href="https://lacasitadeingles.com" target="_blank"
         class="underline">La Casita de Inglés</a> · <a href="https://lacasitadeingles.com/aviso-legal" target="_blank"
-        class="underline">Aviso legal</a> | <a href="https://lacasitadeingles.com/politica-de-privacidad/"
-        target="_blank" class="underline">Privacidad</a>
+        class="underline">Avís legal</a> | <a href="https://lacasitadeingles.com/politica-de-privacidad/"
+        target="_blank" class="underline">Privacitat</a>
     </p>
   </footer>
 
@@ -603,41 +603,41 @@
     <div class="bg-white rounded-xl p-6 max-w-md w-full relative">
       <button @click="close"
         class="absolute top-2 right-2 w-8 h-8 text-2xl flex items-center justify-center text-gray-500">✕</button>
-      <h2 class="text-2xl font-bold mb-4">Contáctanos</h2>
+      <h2 class="text-2xl font-bold mb-4">Contacta'ns</h2>
       <div x-show="!success">
         <form @submit.prevent="submit()" class="space-y-4">
           <input type="hidden" x-model="form.program">
           <div>
-            <label class="block mb-1 font-bold">Academia</label>
+            <label class="block mb-1 font-bold">Acadèmia</label>
             <div class="flex gap-2 items-stretch">
               <select x-model="form.academia" class="flex-1 min-w-0 border rounded p-2" required>
                 <template x-for="loc in locations" :key="loc.name">
                   <option :value="loc.name" x-text="loc.name" :selected="loc.name === form.academia"></option>
                 </template>
               </select>
-              <button type="button" @click="goToLocations" class="px-2 rounded bg-brand-pink text-white shrink-0" title="Buscar">Buscar</button>
+              <button type="button" @click="goToLocations" class="px-2 rounded bg-brand-pink text-white shrink-0" title="Cercar">Cercar</button>
             </div>
           </div>
           <div class="flex gap-2">
             <div class="flex-1">
-              <label class="block mb-1 font-bold">Nombre *</label>
+              <label class="block mb-1 font-bold">Nom *</label>
               <input type="text" x-model="form.nombre" class="w-full border rounded p-2" required>
             </div>
             <div class="flex-1">
-              <label class="block mb-1 font-bold">Apellido *</label>
+              <label class="block mb-1 font-bold">Cognom *</label>
               <input type="text" x-model="form.apellido" class="w-full border rounded p-2" required>
             </div>
           </div>
           <div>
-            <label class="block mb-1 font-bold">Email *</label>
+            <label class="block mb-1 font-bold">Correu electrònic *</label>
             <input type="email" x-model="form.email" class="w-full border rounded p-2" required>
           </div>
           <div>
-            <label class="block mb-1 font-bold">Número de teléfono *</label>
+            <label class="block mb-1 font-bold">Número de telèfon *</label>
             <input type="tel" x-model="form.telefono" class="w-full border rounded p-2" required>
           </div>
           <div>
-            <label class="block mb-1 font-bold">Año de nacimiento de tu(s) peque(s) *</label>
+            <label class="block mb-1 font-bold">Any de naixement del(s) teu(s) petit(s) *</label>
             <div class="w-full border rounded p-2 flex flex-wrap gap-2" @click="$refs.anoInput.focus()">
               <template x-for="(year, index) in form.anos" :key="index">
                 <span class="bg-brand-pink/20 text-brand-pink px-2 py-1 rounded-full flex items-center">
@@ -646,20 +646,20 @@
                 </span>
               </template>
               <input x-ref="anoInput" x-model="anoTemp" @keydown="digitsOnly($event)" @keydown.enter.prevent="handleAno" @blur="handleAno" @input="handleAno"
-                inputmode="numeric" pattern="\\d{4}" placeholder="Ej. 2021"
+                inputmode="numeric" pattern="\\d{4}" placeholder="Ex. 2021"
                 class="flex-1 min-w-[80px] outline-none border-0 p-0">
             </div>
-            <p x-show="!anoError" class="text-gray-500 text-xs mt-1">Puedes añadir más de un año.</p>
+            <p x-show="!anoError" class="text-gray-500 text-xs mt-1">Pots afegir més d'un any.</p>
             <p x-show="anoError" x-text="anoError" class="text-red-500 text-xs mt-1"></p>
           </div>
           <div class="flex items-center">
             <input type="checkbox" x-model="form.privacy" class="mr-2" required>
-            <label>Acepto la <a href="https://lacasitadeingles.com/politica-de-privacidad/"
-        target="_blank" class="underline">Política de Privacidad</a> *</label>
+            <label>Accepto la <a href="https://lacasitadeingles.com/politica-de-privacidad/"
+        target="_blank" class="underline">Política de Privacitat</a> *</label>
           </div>
           <div class="flex items-center">
             <input type="checkbox" x-model="form.newsletter" class="mr-2">
-            <label>Suscribirme al newsletter</label>
+            <label>Subscriure'm al butlletí</label>
           </div>
           <div x-show="message" x-text="message" class="bg-red-100 border border-red-400 text-red-700 rounded p-2 text-center text-sm"></div>
           <div class="flex mt-2">
@@ -670,7 +670,7 @@
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
               </svg>
-              <span x-text="submitting ? 'Enviando...' : 'Enviar'"></span>
+              <span x-text="submitting ? 'Enviant...' : 'Enviar'"></span>
             </button>
           </div>
         </form>
@@ -695,7 +695,7 @@
     <div class="bg-white rounded-xl p-6 max-w-md w-full relative">
       <button @click="closeReviews"
         class="absolute top-2 right-2 w-8 h-8 text-2xl flex items-center justify-center text-gray-500">✕</button>
-      <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">Opiniones en <img src="img/google_on_white_hdpi.png"
+      <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">Opinions a <img src="img/google_on_white_hdpi.png"
           alt="Google" class="h-7 mb-0 inline-block align-middle" /></h2>
 
       <template x-if="!selectedLocation">
@@ -707,10 +707,10 @@
                 <p class="text-sm">
                   <span x-text="loc.rating.toFixed(1)"></span>
                   <span x-html="starIcons(loc.rating)" class="ml-1"></span>
-                  (<span x-text="loc.user_ratings_total"></span> reseñas)
+                  (<span x-text="loc.user_ratings_total"></span> ressenyes)
                 </p>
               </div>
-              <a href="#" @click.prevent="viewReviews(loc)" class="text-brand-pink underline text-sm">ver reseñas</a>
+              <a href="#" @click.prevent="viewReviews(loc)" class="text-brand-pink underline text-sm">veure ressenyes</a>
             </li>
           </template>
         </ul>
@@ -728,15 +728,15 @@
                   <span x-html="starIcons(rev.rating)" class="ml-1"></span>
                 </p>
                 <p class="text-sm" x-text="rev.text"></p>
-                <p class="text-xs text-gray-500" x-text="new Date(rev.time * 1000).toLocaleDateString('es-ES')"></p>
+                <p class="text-xs text-gray-500" x-text="new Date(rev.time * 1000).toLocaleDateString('ca-ES')"></p>
               </li>
             </template>
           </ul>
           <button @click="selectedLocation=null"
-            class="w-full bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-full">Volver a academias</button>
+            class="w-full bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-full">Tornar a acadèmies</button>
           <a :href="`https://www.google.com/maps/search/?api=1&query_place_id=${selectedLocation.place_id}&query=${selectedLocation.lat},${selectedLocation.lon}`"
-            target="_blank" class="block text-xs text-gray-400 underline text-center mt-2 mb-2 link-google-reviews">Ver
-            más reseñas en Google</a>
+            target="_blank" class="block text-xs text-gray-400 underline text-center mt-2 mb-2 link-google-reviews">Veure
+            més ressenyes a Google</a>
         </div>
       </template>
 
@@ -865,7 +865,7 @@
               this.anoError = '';
               return;
             }
-            this.anoError = `El año debe estar entre ${min} y ${current}.`;
+            this.anoError = `L'any ha d'estar entre ${min} i ${current}.`;
             this.anoTemp = '';
           } else {
             this.anoError = '';
@@ -881,7 +881,7 @@
           window.PLACES_SERVICE.getDetails({
             placeId: loc.place_id,
             fields: ['review'],
-            language: 'es'
+            language: 'ca'
           }, (place, status) => {
             if (status === google.maps.places.PlacesServiceStatus.OK && place.reviews) {
               this.reviews = place.reviews.filter(r => r.rating >= 4).slice(0, 5);
@@ -898,14 +898,14 @@
           /*         Validación de campos */
           this.message = '';
           if (!this.form.nombre || !this.form.apellido || !this.form.email || !this.form.telefono || this.form.anos.length === 0 || !this.form.academia) {
-            this.message = 'Por favor, completa todos los campos requeridos';
+            this.message = 'Si us plau, completa tots els camps requerits';
             this.submitting = false;
             return;
           }
           let digits = this.form.telefono.replace(/\D/g, '');
           if (digits.startsWith('34')) digits = digits.slice(2);
           if (!/^[67]\d{8}$/.test(digits)) {
-            this.message = 'Introduce un número de móvil válido';
+            this.message = 'Introdueix un número de mòbil vàlid';
             this.submitting = false;
             return;
           }
@@ -914,12 +914,12 @@
             const age = current - parseInt(y, 10);
             return !isNaN(age) && age < 13 && age >= 0;
           })) {
-            this.message = 'El año de nacimiento debe corresponder a un niño menor de 13 años';
+            this.message = 'L'any de naixement ha de correspondre a un infant menor de 13 anys';
             this.submitting = false;
             return;
           }
           if (!this.form.privacy) { 
-            this.message = 'Acepta la política de privacidad'; this.submitting = false; return; 
+            this.message = 'Accepta la política de privacitat'; this.submitting = false; return;
           }
           
           
@@ -956,7 +956,7 @@
             });
           } catch (err) {
             window.dataLayer?.push({ event: 'leadFormError' });
-            this.message = "Ha ocurrido un error inesperado. Por favor, envíanos un email a retiro@lacasitadeingles.com.";
+            this.message = "S'ha produït un error inesperat. Si us plau, envia'ns un correu a retiro@lacasitadeingles.com.";
             this.submitting = false;
             clearTimeout(timeout);
             return;
@@ -964,7 +964,7 @@
           clearTimeout(timeout);
 
           if (resp.ok) {
-            this.message = 'Solicitud enviada. Nos pondremos en contacto en breve 🎉';
+            this.message = 'Sol·licitud enviada. Ens posarem en contacte aviat 🎉';
             const formData = { ...this.form, ano: this.form.anos.join(', ') };
             this.lastFormData = formData;
             this.form = { academia: randomDefault.name, email_academia: randomDefault.email, nombre: '', apellido: '', email: '', telefono: '', anos: [], program: '', privacy: false, newsletter: false, ...this.initialUtm };
@@ -972,7 +972,7 @@
             this.success = true;
           } else {
             window.dataLayer?.push({ event: 'leadFormError' });
-            this.message = "Ha ocurrido un error inesperado. Por favor, envíanos un email a retiro@lacasitadeingles.com.";
+            this.message = "S'ha produït un error inesperat. Si us plau, envia'ns un correu a retiro@lacasitadeingles.com.";
           }
           this.submitting = false;
         },
@@ -982,7 +982,7 @@
           const loc = locations.find(l => l.name === data.academia);
           let phone = loc?.phone ? loc.phone.replace(/\D/g, '') : '621070732';
           if (!phone.startsWith('34')) phone = '34' + phone;
-          const text = `Hola! He completado el formulario de contacto y me gustaría saber más sobre La Casita de Inglés.\nNombre: ${data.nombre} ${data.apellido}\nEmail: ${data.email}\nTel: ${data.telefono}\nAño alumno: ${data.ano}\nAcademia:  ${data.academia}\nPrograma: ${data.program}`;
+          const text = `Hola! He completat el formulari de contacte i m'agradaria saber més sobre La Casita de Inglés.\nNom: ${data.nombre} ${data.apellido}\nCorreu: ${data.email}\nTel: ${data.telefono}\nAny alumne: ${data.ano}\nAcadèmia:  ${data.academia}\nPrograma: ${data.program}`;
           const url = 'https://wa.me/' + phone + '?text=' + encodeURIComponent(text);
           setTimeout(() => { window.location.href = url; }, 300);
         },


### PR DESCRIPTION
## Summary
- Translate navigation, hero, programs, testimonials, and contact modal to Catalan.
- Center the interactive map on Catalonia instead of Madrid.
- Adjust review and contact form messages for Catalan locale and date formatting.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac80d3af78832b9886d3ecc26c79c9