### PR TITLE
Mostrar solo academias de Sant Cugat y Poblenou

### DIFF
--- a/cataluna.html
+++ b/cataluna.html
@@ -260,7 +260,7 @@
       <h1
         class="relative z p-1-10 text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4"
       >
-        ¡El Inglés más divertido!
+        L'anglès més divertit!
       </h1>
       <p class="relative z-10 text-lg sm:text-xl mb-4 p-1">
         Profesores nativos · Grupos reducidos · Play-Based Learning

--- a/index.html
+++ b/index.html
@@ -39,130 +39,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     const locations = [
       {
-        "name": "Retiro / Pacifico",
-        "address": "Calle José Sánchez Pescador 10, Madrid, 28007",
-        "phone": "621 070 732",
-        "email": "retiro@lacasitadeingles.com",
-        "lat": 40.4066036,
-        "lon": -3.6786666,
-        "rating": null,
-        "user_ratings_total": null,
-        "default": true,
-        "owned_postcodes": ["28007", "28014", "28009", "28045"]
-      },
-      {
-        "name": "Alameda de Osuna",
-        "address": "Calle Noray 6, Barajas, Madrid, 28042",
-        "phone": "602 676 247",
-        "email": "alameda@lacasitadeingles.com",
-        "lat": 40.4512542,
-        "lon": -3.5959718,
-        "rating": null,
-        "user_ratings_total": null
-      },
-      {
-        "name": "Alcobendas",
-        "address": "Paseo de Fuente Lucha, 20, Alcobendas, Madrid",
-        "phone": "633 20 52 16",
-        "email": "alcobendas@lacasitadeingles.com",
-        "lat": 40.5556707,
-        "lon": -3.6591499,
-        "place_id": "ChIJNeudKDUtQg0R-HpmAwBWI7A",
-        "rating": 4.9,
-        "user_ratings_total": 81,
-        "default": true
-      },
-      {
-        "name": "Barrio de Salamanca",
-        "address": "Calle Padilla 88, Madrid, Madrid, 28006",
-        "phone": "686 74 75 37",
-        "email": "padilla@lacasitadeingles.com",
-        "lat": 40.4309117,
-        "lon": -3.6717126,
-        "place_id": "ChIJGWiYEE8pQg0R3HzavORc23E",
-        "rating": 4.9,
-        "user_ratings_total": 34
-      },
-      {
-        "name": "Boadilla del Monte",
-        "address": "Calle Isabel de Farnesio, 27, Boadilla del Monte, Madrid, 28660",
-        "phone": "722 171 335",
-        "email": "boadilla@lacasitadeingles.com",
-        "lat": 40.4053485,
-        "lon": -3.8764663,
-        "place_id": "ChIJXyCiHnaPQQ0RhOMDi8E0QkQ",
-        "rating": 5,
-        "user_ratings_total": 61,
-        "default": true
-      },
-      {
-        "name": "Carabanchel",
-        "address": "Avenida del Euro 72, Madrid, Madrid, 28054",
-        "phone": "613 332 838",
-        "email": "carabanchel@lacasitadeingles.com",
-        "lat": 40.3665754,
-        "lon": -3.7431719,
-        "place_id": "ChIJqYYX0WiJQQ0RiLJxGRIl1I8",
-        "rating": 5,
-        "user_ratings_total": 18
-      },
-      {
-        "name": "Chamberí",
-        "address": "Calle Fernández de la Hoz, 80, Madrid, 28003",
-        "phone": "607 54 00 67",
-        "email": "chamberi@lacasitadeingles.com",
-        "lat": 40.4398329,
-        "lon": -3.6944202,
-        "place_id": "ChIJb0HitvEoQg0ROeBdzL2qjmM",
-        "rating": 5,
-        "user_ratings_total": 93
-      },
-      {
-        "name": "Getafe",
-        "address": "Avenida de Chile, 2A, Getafe, Madrid, 28907",
-        "phone": "671 75 59 02",
-        "email": "getafe@lacasitadeingles.com",
-        "lat": 40.3189137,
-        "lon": -3.7388004,
-        "place_id": "ChIJFa37ZSMhQg0RHoKiOS8R-hY",
-        "rating": 5,
-        "user_ratings_total": 63
-      },
-      {
-        "name": "Leganés",
-        "address": "Avenida Vicente Ferrer 3, Leganes, Madrid, 28907",
-        "phone": "654 459 779",
-        "email": "leganes@lacasitadeingles.com",
-        "lat": 40.3377178,
-        "lon": -3.780993,
-        "place_id": "ChIJb-YOsYeJQQ0R8d3HBP0tuNk",
-        "rating": 4.9,
-        "user_ratings_total": 14
-      },
-      {
-        "name": "Majadahonda",
-        "address": "Calle del Puerto de los Leones, 1, Majadahonda, Madrid, 28220",
-        "phone": "676 785 076",
-        "email": "majadahonda@lacasitadeingles.com",
-        "lat": 40.4775751,
-        "lon": -3.8789657,
-        "place_id": "ChIJk4CPNGeGQQ0R96CyH0QiC1E",
-        "rating": 4.9,
-        "user_ratings_total": 77,
-        "default": true
-      },
-      {
-        "name": "Montecarmelo",
-        "address": "Calle del Monasterio de Oseira, 9, Madrid, 28049",
-        "phone": "671 244 181",
-        "email": "montecarmelo@lacasitadeingles.com",
-        "lat": 40.509493,
-        "lon": -3.6972066,
-        "place_id": "ChIJt8uDss4rQg0RCRizawx6szo",
-        "rating": 5,
-        "user_ratings_total": 98
-      },
-      {
         "name": "Poblenou (Próximamente)",
         "address": "Carrer de Llull, 256, Barcelona, 08005",
         "phone": "722 501 660",
@@ -170,30 +46,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         "lat": 41.4037675,
         "lon": 2.2059664,
         "rating": null,
-        "user_ratings_total": null
-      },
-      {
-        "name": "Pozuelo de Alarcón",
-        "address": "Calle Ámbar, 9, Pozuelo de Alarcón, Madrid, 28224",
-        "phone": "699 936 373",
-        "email": "pozuelo@lacasitadeingles.com",
-        "lat": 40.4412998,
-        "lon": -3.7970479,
-        "place_id": "ChIJp7uGYb8pQg0R27dLASD5_ZY",
-        "rating": 4.9,
-        "user_ratings_total": 127,
+        "user_ratings_total": null,
         "default": true
-      },
-      {
-        "name": "Sanchinarro",
-        "address": "Calle Padre Dominicos, 34, Madrid, 28050",
-        "phone": "644 820 738",
-        "email": "sanchinarro@lacasitadeingles.com",
-        "lat": 40.4931887,
-        "lon": -3.6564023,
-        "place_id": "ChIJmfXTle4tQg0RRoc44JriT1k",
-        "rating": 4.9,
-        "user_ratings_total": 106
       },
       {
         "name": "Sant Cugat del Vallès",
@@ -205,27 +59,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         "place_id": "ChIJlZ5CHmqRpBIRtd7ioQ_uPP4",
         "rating": 5,
         "user_ratings_total": 62
-      },
-      {
-        "name": "Ensanche de Vallecas",
-        "address": "C. Embalse de Pinilla, 53, 28051 Madrid, Spain",
-        "phone": "622 441 019",
-        "email": "vallecas@lacasitadeingles.com",
-        "lat": 40.3595482,
-        "lon": -3.595116,
-        "place_id": "ChIJ__B6zR4lQg0R3qoLX40VbEA",
-        "rating": 5,
-        "user_ratings_total": 80
-      },
-      {
-        "name": "Vigo (Próximamente)",
-        "address": "Rúa do Uruguai, 15, Vigo, 36201",
-        "phone": "623 202 594",
-        "email": "vigo@lacasitadeingles.com",
-        "lat": 42.1190558,
-        "lon": -8.8553034,
-        "rating": null,
-        "user_ratings_total": null
       }
     ];
     const defaultLocations = locations.filter(l => l.default);
@@ -344,7 +177,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <ul class="relative z-10 flex flex-wrap justify-center gap-4 text-xs text-white/80 mb-8">
       <li>20 años de experiencia</li>
       <li class="hidden sm:inline">17 k seguidores</li>
-      <li>14 academias en Madrid</li>
+      <li>2 academias en Barcelona</li>
     </ul>
     <div class="relative z-10 mb-6">
       <a href="#" @click.prevent="openReviews()"
@@ -547,7 +380,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        const map = L.map('map').setView([40.4066036, -3.6786666], 11);
+        const map = L.map('map').setView([41.4037675, 2.2059664], 11);
         window.MAP = map;
         // Use CartoDB Positron (light, greyish) tiles
         L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- Hero -->
   <section id="hero" :class="[heroClass, 'relative text-white text-center flex flex-col items-center justify-center']">
     <div class="absolute inset-0 bg-gradient-to-b from-black/60 to-black/30"></div>
-    <h1 class="relative z p-1-10 text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4">¡El Inglés más divertido!</h1>
+    <h1 class="relative z p-1-10 text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4">L'anglès més divertit!</h1>
     <p class="relative z-10 text-lg sm:text-xl mb-4 p-1">Profesores nativos · Grupos reducidos · Play-Based Learning</p>
     <ul class="relative z-10 flex flex-wrap justify-center gap-4 text-xs text-white/80 mb-8">
       <li>20 años de experiencia</li>


### PR DESCRIPTION
## Summary
- Limitar el listado de academias a Sant Cugat y Poblenou.
- Centrar el mapa en Barcelona y actualizar el conteo de academias.

## Testing
- `npx -y htmlhint index.html` *(falló: 403 Forbidden)*
- `npm test` *(falló: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68b064e27138832bb281df477ab2e4d8